### PR TITLE
Minor comment correctin in ray_triangle.rs

### DIFF
--- a/src/query/ray/ray_triangle.rs
+++ b/src/query/ray/ray_triangle.rs
@@ -42,7 +42,7 @@ pub fn ray_intersection_with_triangle<N: RealField>(
     let n = ab.cross(&ac);
     let d = n.dot(&ray.dir);
 
-    // the normal and the ray direction are parallel
+    // the normal and the ray direction are perpendicular
     if d.is_zero() {
         return None;
     }


### PR DESCRIPTION
For ray_intersection_with_triangle, the comment claims to exit the function when the ray is parallel with the normal, but it actually exits when the ray is perpendicular.